### PR TITLE
reducefunctionsfix - Removes Lambda function creation from each stack…

### DIFF
--- a/cloudformation/online-trial-control.yaml
+++ b/cloudformation/online-trial-control.yaml
@@ -29,6 +29,7 @@
             - MinimumStackCount
             - OnlineTrialsSubnetId
             - OnlineTrialsVPCId
+            - TrialLifetimeInDays
         - Label:
             default: Sensitive Parameters
           Parameters:
@@ -107,6 +108,10 @@
       Default: arn:aws:iam::823267158217:role/OktaAdminRole
       AllowedValues:
         - arn:aws:iam::823267158217:role/OktaAdminRole
+    TrialLifetimeInDays:
+      Description: How long in days before the instance is stopped
+      Type: Number
+      Default: 14
     UpdatedTime:
       Type: String
       Description: The time in ms that this stack was updated
@@ -1322,6 +1327,41 @@
                     - logs:PutLogEvents
                   Resource:
                     - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+    TrialRoute53DomainNameGenerator:
+      Type: AWS::Lambda::Function
+      Properties:
+        Code:
+          ZipFile: |
+            from __future__ import print_function
+            from datetime import datetime, timedelta
+            import os
+            import cfnresponse
+            import random
+            import string
+
+            def handler(event, context):
+              try:
+                if event['RequestType'] == 'Create':
+                  name = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(6))
+                  responseData = {}
+                  responseData['DomainName'] = name
+                  d = datetime.today() + timedelta(days=int(os.environ['days_to_stop']))
+                  responseData['ExpiryDate'] = d.date().strftime('%d-%m-%Y')
+                  print(responseData)
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+                else:
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as err:
+                print("{}\n".format(err))
+                cfnresponse.send(event, context, cfnresponse.FAILED, {})
+        Environment:
+          Variables:
+            days_to_stop: !Ref TrialLifetimeInDays
+        FunctionName: !If [CreatedByBamboo, !Ref "AWS::NoValue", !Sub "DomainNameGenerator-${Stage}"]
+        Handler: index.handler
+        Role: !GetAtt TrialRoute53DomainNameGenIamRole.Arn
+        Runtime: python2.7
+        Timeout: 10
     TrialSubnetIdAllocatorIamRole:
       Type: AWS::IAM::Role
       Properties:
@@ -1356,6 +1396,48 @@
                     - ec2:DescribeSubnets
                   Resource:
                     - "*"
+    TrialSubnetIdAllocator:
+      Type: AWS::Lambda::Function
+      Properties:
+        Code:
+          ZipFile: |
+            from __future__ import print_function
+            import cfnresponse
+            import os
+            import boto3
+            import random
+
+            def handler(event, context):
+              client = boto3.client('ec2')
+              try:
+                if event['RequestType'] == 'Create':
+                  response = client.describe_subnets(
+                    Filters=[{
+                        'Name': 'vpc-id',
+                        'Values': [os.environ['vpc_id']]
+                      }
+                    ]
+                  )
+
+                  subnets = []
+                  for subnet in response['Subnets']:
+                    print("Adding {} to subnet list".format(subnet['SubnetId']))
+                    subnets.append(subnet['SubnetId'])
+
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SubnetId' : random.choice(subnets)})
+                else:
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as err:
+                print("{}\n".format(err))
+                cfnresponse.send(event, context, cfnresponse.FAILED, {})
+        Environment:
+          Variables:
+            vpc_id: !Ref OnlineTrialsVPCId
+        FunctionName: !If [CreatedByBamboo, !Ref "AWS::NoValue", !Sub "SubnetAllocator-${Stage}"]
+        Handler: index.handler
+        Role: !GetAtt TrialSubnetIdAllocatorIamRole.Arn
+        Runtime: python2.7
+        Timeout: 10
     TrialRoute53RecordSetIamRole:
       Type: AWS::IAM::Role
       Properties:
@@ -1396,6 +1478,66 @@
                     - sts:AssumeRole
                   Resource:
                     - !Ref SystemsRole
+    TrialRoute53RecordSetHandler:
+      Type: AWS::Lambda::Function
+      Properties:
+        Code:
+          ZipFile: |
+            from __future__ import print_function
+            import cfnresponse
+            import os
+            import boto3
+
+            def handler(event, context):
+              try:
+                sts = boto3.client('sts')
+                role = sts.assume_role(
+                  RoleArn=os.environ['role'],
+                  RoleSessionName=event['ResourceProperties']['Name']
+                )
+                print("Role Assumed OK")
+                client = boto3.client(
+                  'route53',
+                  aws_access_key_id=role['Credentials']['AccessKeyId'],
+                  aws_secret_access_key=role['Credentials']['SecretAccessKey'],
+                  aws_session_token=role['Credentials']['SessionToken']
+                )
+                print("Cross account R53 client created OK")
+                action = 'DELETE' if event['RequestType'] == 'Delete' else 'UPSERT'
+                requestData = {
+                  'Changes': [
+                    {
+                      'Action': action,
+                      'ResourceRecordSet': {
+                        'Name': "{}.trial.alfresco.com.".format(event['ResourceProperties']['Name']),
+                        'Type': 'A',
+                        'TTL': 300,
+                        'ResourceRecords': [
+                          {
+                            'Value': event['ResourceProperties']['PublicIp']
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                response = client.change_resource_record_sets(
+                  HostedZoneId=os.environ['hosted_zone_id'],
+                  ChangeBatch=requestData
+                )
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as err:
+                print("{}\n".format(err))
+                cfnresponse.send(event, context, cfnresponse.FAILED, {})
+        Environment:
+          Variables:
+            hosted_zone_id: Z2KYYIWHSJMSS1
+            role: !Ref SystemsRole
+        FunctionName: !If [CreatedByBamboo, !Ref "AWS::NoValue", !Sub "RecordSetCreator-${Stage}"]
+        Handler: index.handler
+        Role: !GetAtt TrialRoute53RecordSetIamRole.Arn
+        Runtime: python2.7
+        Timeout: 30
     TrialOpsWorkRegisterHandlerIamRole:
       Type: AWS::IAM::Role
       Properties:
@@ -1431,6 +1573,53 @@
                     - opsworks:DeregisterInstance
                   Resource:
                     - "*"
+    TrialOpsWorksRegisterHandler:
+      Type: AWS::Lambda::Function
+      Properties:
+        Code:
+          ZipFile: |
+            from __future__ import print_function
+            import cfnresponse
+            import os
+            import boto3
+
+            def handler(event, context):
+              try:
+                client = boto3.client('opsworks')
+                eventType = event['RequestType']
+                if eventType == 'Create' or eventType == 'Delete':
+                  response = client.describe_instances(
+                    StackId=os.environ['stack_id']
+                  )
+                  data = {}
+                  for instance in response['Instances']:
+                    if instance['Hostname'] == event['ResourceProperties']['Hostname']:
+                      print("Instance found - {}".format(instance['InstanceId']))
+                      if eventType == 'Create':
+                        data['InstanceId'] = instance['InstanceId']
+                        cfnresponse.send(event, context, cfnresponse.SUCCESS, data)
+                        break
+                      elif eventType == 'Delete':
+                        deregisterResp = client.deregister_instance(
+                          InstanceId=instance['InstanceId']
+                        )
+                        print("Instance deregistered from stack")
+                        cfnresponse.send(event, context, cfnresponse.SUCCESS, data)
+                        break
+                      
+                else:
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as err:
+                print("{}\n".format(err))
+                cfnresponse.send(event, context, cfnresponse.FAILED, {})
+        Environment:
+          Variables:
+            stack_id: !Ref OnlineTrialOpsWorksStack
+        FunctionName: !If [CreatedByBamboo, !Ref "AWS::NoValue", !Sub "OpsWorksRegisterer-${Stage}"]
+        Handler: index.handler
+        Role: !GetAtt TrialOpsWorkRegisterHandlerIamRole.Arn
+        Runtime: python2.7
+        Timeout: 30
     TrialOpsWorksInitialiseInstanceCookbooksIamRole:
       Type: AWS::IAM::Role
       Properties:
@@ -1465,6 +1654,44 @@
                     - opsworks:CreateDeployment
                   Resource:
                     - "*"
+    TrialOpsWorksInitInstanceCookbookHandler:
+      Type: AWS::Lambda::Function
+      Properties:
+        Code:
+          ZipFile: |
+            from __future__ import print_function
+            import cfnresponse
+            import os
+            import boto3
+
+            def handler(event, context):
+              try:
+                if event['RequestType'] == 'Create':
+                  client = boto3.client('opsworks')
+                  instance_id = event['ResourceProperties']['InstanceId']
+                  response = client.create_deployment(
+                    StackId=os.environ['stack_id'],
+                    InstanceIds=[instance_id],
+                    Command={
+                      'Name': 'update_custom_cookbooks'
+                    },
+                    Comment="Updating cookbooks on {}".format(instance_id)
+                  )
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
+                else:
+                  print("Event is {}, doing nothing".format(event['RequestType']))
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as err:
+                print("{}\n".format(err))
+                cfnresponse.send(event, context, cfnresponse.FAILED, {})
+        Environment:
+          Variables:
+            stack_id: !Ref OnlineTrialOpsWorksStack
+        FunctionName: !If [CreatedByBamboo, !Ref "AWS::NoValue", !Sub "CookbookRunner-${Stage}"]
+        Handler: index.handler
+        Role: !GetAtt TrialOpsWorksInitialiseInstanceCookbooksIamRole.Arn
+        Runtime: python2.7
+        Timeout: 10
   Outputs:
     DistributionName:
       Description: The CloudFront distribution name to point a R53 entry to.
@@ -1503,6 +1730,33 @@
       Value: !Ref OpsWorksLayerSecurityGroups
       Export:
         Name: !Sub "${AWS::StackName}-OpsWorksLayerSecurityGroups"
+    # These Outputs below are Lambdas reused by all the child stacks
+    DomainNameGenerator:
+      Description: The Lambda ARN of the function that generates a random domain name
+      Value: !GetAtt TrialRoute53DomainNameGenerator.Arn
+      Export:
+        Name: !Sub "${AWS::StackName}-DomainNameGenerator"
+    SubnetAllocator:
+      Description: The Lambda ARN of the function that allocates a subnet to an instance
+      Value: !GetAtt TrialSubnetIdAllocator.Arn
+      Export:
+        Name: !Sub "${AWS::StackName}-SubnetAllocator"
+    RecordSetCreator:
+      Description: The Lambda ARN of the function that creates a R53 record set
+      Value: !GetAtt TrialRoute53RecordSetHandler.Arn
+      Export:
+        Name: !Sub "${AWS::StackName}-RecordSetCreator"
+    OpsWorkRegister:
+      Description: The Lambda ARN of the function that registers/deregisters an instance with OpsWorks
+      Value: !GetAtt TrialOpsWorksRegisterHandler.Arn
+      Export:
+        Name: !Sub "${AWS::StackName}-OpsWorkRegister"
+    CookbookRunner:
+      Description: The Lambda ARN of the function that pushes our custom cookbooks onto each instance
+      Value: !GetAtt TrialOpsWorksInitInstanceCookbookHandler.Arn
+      Export:
+        Name: !Sub "${AWS::StackName}-CookbookRunner"
+    # These Outputs below can be removed once all the stacks have stopped using them
     StandardLoggingRole:
       Description: IAM Role ARN to be used by Lambdas simply for logging
       Value: !GetAtt TrialRoute53DomainNameGenIamRole.Arn

--- a/cloudformation/online-trial-stack.yaml
+++ b/cloudformation/online-trial-stack.yaml
@@ -10,7 +10,6 @@
             - TrialAMIId
             - TrialInstanceType
             - TrialSSHKey
-            - TrialLifetimeInDays
         - Label:
             default: Control Architecture Configuration
           Parameters:
@@ -49,101 +48,17 @@
       Description: The name of an existing EC2 KeyPair
       Type: AWS::EC2::KeyPair::KeyName
       Default: salty-trials
-    TrialLifetimeInDays:
-      Description: How long in days before the instance is stopped
-      Type: Number
-      Default: 14
   Resources:
-    TrialRoute53DomainNameGenerator:
-      Type: AWS::Lambda::Function
-      Properties:
-        Code:
-          ZipFile: |
-            from __future__ import print_function
-            from datetime import datetime, timedelta
-            import os
-            import cfnresponse
-            import random
-            import string
-
-            def handler(event, context):
-              try:
-                if event['RequestType'] == 'Create':
-                  name = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(6))
-                  responseData = {}
-                  responseData['DomainName'] = name
-                  d = datetime.today() + timedelta(days=int(os.environ['days_to_stop']))
-                  responseData['ExpiryDate'] = d.date().strftime('%d-%m-%Y')
-                  print(responseData)
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
-                else:
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-              except Exception as err:
-                print("{}\n".format(err))
-                cfnresponse.send(event, context, cfnresponse.FAILED, {})
-        Environment:
-          Variables:
-            days_to_stop: !Ref TrialLifetimeInDays
-        Handler: index.handler
-        Role:
-          Fn::ImportValue: !Sub "${ControlArchitectureName}-StandardLoggingRole"
-        Runtime: python2.7
-        Timeout: 10
     TrialRoute53DomainNameGenCustomResource:
       Type: Custom::DomainName
-      DependsOn:
-        - TrialRoute53DomainNameGenerator
       Properties:
-        ServiceToken: !GetAtt TrialRoute53DomainNameGenerator.Arn
-    TrialSubnetIdAllocator:
-      Type: AWS::Lambda::Function
-      Properties:
-        Code:
-          ZipFile: |
-            from __future__ import print_function
-            import cfnresponse
-            import os
-            import boto3
-            import random
-
-            def handler(event, context):
-              client = boto3.client('ec2')
-              try:
-                if event['RequestType'] == 'Create':
-                  response = client.describe_subnets(
-                    Filters=[{
-                        'Name': 'vpc-id',
-                        'Values': [os.environ['vpc_id']]
-                      }
-                    ]
-                  )
-
-                  subnets = []
-                  for subnet in response['Subnets']:
-                    print("Adding {} to subnet list".format(subnet['SubnetId']))
-                    subnets.append(subnet['SubnetId'])
-
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {'SubnetId' : random.choice(subnets)})
-                else:
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-              except Exception as err:
-                print("{}\n".format(err))
-                cfnresponse.send(event, context, cfnresponse.FAILED, {})
-        Environment:
-          Variables:
-            vpc_id:
-              Fn::ImportValue: !Sub "${ControlArchitectureName}-OnlineTrialsVPCId"
-        Handler: index.handler
-        Role:
-          Fn::ImportValue: !Sub "${ControlArchitectureName}-SubnetIdRole"
-        Runtime: python2.7
-        Timeout: 10
+        ServiceToken:
+          Fn::ImportValue: !Sub "${ControlArchitectureName}-DomainNameGenerator"
     TrialSubnetIdAllocatorCustomResource:
       Type: Custom::GetSubnetId
-      DependsOn:
-        - TrialSubnetIdAllocator
       Properties:
-        ServiceToken: !GetAtt TrialSubnetIdAllocator.Arn
+        ServiceToken:
+          Fn::ImportValue: !Sub "${ControlArchitectureName}-SubnetAllocator"
     TrialEc2Instance:
       Type: AWS::EC2::Instance
       CreationPolicy:
@@ -320,183 +235,29 @@
                   # Add Suricata and Evebox agent installation, configuration and provisioning
                   # script only accessible from trials VPC
                   # curl -s https://s3.amazonaws.com/online-trial-control-ttp/installation-suricata-agent-mode.sh | bash -s --
-    TrialRoute53RecordSetHandler:
-      Type: AWS::Lambda::Function
-      DependsOn:
-        - TrialEc2Instance
-      Properties:
-        Code:
-          ZipFile: |
-            from __future__ import print_function
-            import cfnresponse
-            import os
-            import boto3
-
-            def handler(event, context):
-              try:
-                sts = boto3.client('sts')
-                role = sts.assume_role(
-                  RoleArn=os.environ['role'],
-                  RoleSessionName=os.environ['name']
-                )
-                print("Role Assumed OK")
-                client = boto3.client(
-                  'route53',
-                  aws_access_key_id=role['Credentials']['AccessKeyId'],
-                  aws_secret_access_key=role['Credentials']['SecretAccessKey'],
-                  aws_session_token=role['Credentials']['SessionToken']
-                )
-                print("Cross account R53 client created OK")
-                action = 'DELETE' if event['RequestType'] == 'Delete' else 'UPSERT'
-                requestData = {
-                  'Changes': [
-                    {
-                      'Action': action,
-                      'ResourceRecordSet': {
-                        'Name': "{}.trial.alfresco.com.".format(os.environ['name']),
-                        'Type': 'A',
-                        'TTL': 300,
-                        'ResourceRecords': [
-                          {
-                            'Value': os.environ['public_ip']
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-                response = client.change_resource_record_sets(
-                  HostedZoneId=os.environ['hosted_zone_id'],
-                  ChangeBatch=requestData
-                )
-                cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-              except Exception as err:
-                print("{}\n".format(err))
-                cfnresponse.send(event, context, cfnresponse.FAILED, {})
-        Environment:
-          Variables:
-            hosted_zone_id: Z2KYYIWHSJMSS1
-            name: !GetAtt TrialRoute53DomainNameGenCustomResource.DomainName
-            public_ip: !GetAtt TrialEc2Instance.PublicIp
-            role:
-              Fn::ImportValue: !Sub "${ControlArchitectureName}-SystemsIAMRole"
-        Handler: index.handler
-        Role:
-          Fn::ImportValue: !Sub "${ControlArchitectureName}-Route53Role"
-        Runtime: python2.7
-        Timeout: 30
     TrialRoute53RecordSetCustomResource:
       Type: Custom::CreateRecordSet
       DependsOn:
-        - TrialRoute53RecordSetHandler
-      Properties:
-        ServiceToken: !GetAtt TrialRoute53RecordSetHandler.Arn
-    TrialOpsWorksRegisterHandler:
-      Type: AWS::Lambda::Function
-      DependsOn:
         - TrialEc2Instance
       Properties:
-        Code:
-          ZipFile: |
-            from __future__ import print_function
-            import cfnresponse
-            import os
-            import boto3
-
-            def handler(event, context):
-              try:
-                client = boto3.client('opsworks')
-                eventType = event['RequestType']
-                if eventType == 'Create' or eventType == 'Delete':
-                  response = client.describe_instances(
-                    StackId=os.environ['stack_id']
-                  )
-                  data = {}
-                  for instance in response['Instances']:
-                    if instance['Hostname'] == os.environ['hostname']:
-                      print("Instance found - {}".format(instance['InstanceId']))
-                      if eventType == 'Create':
-                        data['InstanceId'] = instance['InstanceId']
-                        cfnresponse.send(event, context, cfnresponse.SUCCESS, data)
-                        break
-                      elif eventType == 'Delete':
-                        deregisterResp = client.deregister_instance(
-                          InstanceId=instance['InstanceId']
-                        )
-                        print("Instance deregistered from stack")
-                        cfnresponse.send(event, context, cfnresponse.SUCCESS, data)
-                        break
-                      
-                else:
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-              except Exception as err:
-                print("{}\n".format(err))
-                cfnresponse.send(event, context, cfnresponse.FAILED, {})
-        Environment:
-          Variables:
-            hostname: !GetAtt TrialRoute53DomainNameGenCustomResource.DomainName
-            stack_id:
-              Fn::ImportValue: !Sub ${ControlArchitectureName}-OpsWorksStackId
-        Handler: index.handler
-        Role:
-          Fn::ImportValue: !Sub "${ControlArchitectureName}-OpsWorksRegisterRole"
-        Runtime: python2.7
-        Timeout: 30
+        ServiceToken:
+          Fn::ImportValue: !Sub "${ControlArchitectureName}-RecordSetCreator"
+        Name: !GetAtt TrialRoute53DomainNameGenCustomResource.DomainName
+        PublicIp: !GetAtt TrialEc2Instance.PublicIp
     TrialOpsWorksRegisterHandlerCustomResource:
       Type: Custom::OpsWorksRegister
       DependsOn:
-        - TrialOpsWorksRegisterHandler
-      Properties:
-        ServiceToken: !GetAtt TrialOpsWorksRegisterHandler.Arn
-    TrialOpsWorksInitInstanceCookbookHandler:
-      Type: AWS::Lambda::Function
-      DependsOn:
         - TrialEc2Instance
       Properties:
-        Code:
-          ZipFile: |
-            from __future__ import print_function
-            import cfnresponse
-            import os
-            import boto3
-
-            def handler(event, context):
-              try:
-                if event['RequestType'] == 'Create':
-                  client = boto3.client('opsworks')
-                  response = client.create_deployment(
-                    StackId=os.environ['stack_id'],
-                    InstanceIds=[
-                      os.environ['instance_id']
-                    ],
-                    Command={
-                      'Name': 'update_custom_cookbooks'
-                    },
-                    Comment="Updating cookbooks on {}".format(os.environ['instance_id'])
-                  )
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
-                else:
-                  print("Event is {}, doing nothing".format(event['RequestType']))
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-              except Exception as err:
-                print("{}\n".format(err))
-                cfnresponse.send(event, context, cfnresponse.FAILED, {})
-        Environment:
-          Variables:
-            stack_id:
-              Fn::ImportValue: !Sub "${ControlArchitectureName}-OpsWorksStackId"
-            instance_id: !GetAtt TrialOpsWorksRegisterHandlerCustomResource.InstanceId
-        Handler: index.handler
-        Role:
-          Fn::ImportValue: !Sub "${ControlArchitectureName}-OpsWorksCookbookRole"
-        Runtime: python2.7
-        Timeout: 10
+        ServiceToken:
+          Fn::ImportValue: !Sub "${ControlArchitectureName}-OpsWorkRegister"
+        Hostname: !GetAtt TrialRoute53DomainNameGenCustomResource.DomainName
     TrialOpsWorksInitInstanceCookbookCustomResource:
       Type: Custom::OpsWorksCookbookInstaller
-      DependsOn:
-        - TrialOpsWorksInitInstanceCookbookHandler
       Properties:
-        ServiceToken: !GetAtt TrialOpsWorksInitInstanceCookbookHandler.Arn
+        ServiceToken:
+          Fn::ImportValue: !Sub "${ControlArchitectureName}-CookbookRunner"
+        InstanceId: !GetAtt TrialOpsWorksRegisterHandlerCustomResource.InstanceId
   Outputs:
     Type:
       Description: The type of stack this is.


### PR DESCRIPTION
… and adds it to the OTCS

All functions have been moved to the OTCS. Each Trial Stack will reuse each function. This means we will have far less Lambdas deployed.