### PR TITLE
Release v1.3.4

### DIFF
--- a/cloudformation/online-trial-stack.yaml
+++ b/cloudformation/online-trial-stack.yaml
@@ -149,7 +149,7 @@
                 - Fn::ImportValue: !Sub ${ControlArchitectureName}-OpsWorksStackId
                 - "\n"
                 - "aws opsworks register --stack-id ${opsworks_stackid}"
-                - !Sub " --infrastructure-class ec2 --region ${AWS::Region} --local"
+                - !Sub " --infrastructure-class ec2 --region ${AWS::Region} --local --use-instance-profile"
                 - "\n"
                 - !Sub |
                   else


### PR DESCRIPTION
- Added more time in update script to wait for Change set to be created
- Changed timeout on LifecycleHandler Lambda to 180 seconds
- Updated code to use DeleteInstance API not DeregisterInstance API for OpsWorks